### PR TITLE
Add Next.js frontend scaffold

### DIFF
--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-sans bg-white text-gray-800;
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,0 +1,13 @@
+import './globals.css'
+import { Roboto } from 'next/font/google'
+import type { ReactNode } from 'react'
+
+const roboto = Roboto({ subsets: ['latin'], weight: ['400','700'], variable: '--font-roboto' })
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className={roboto.variable}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/apps/frontend/app/login/page.tsx
+++ b/apps/frontend/app/login/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Input from '../../components/Input'
+import Button from '../../components/Button'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!email.endsWith('@ecosleek.in')) {
+      setError('Email must end with @ecosleek.in')
+      return
+    }
+    setError('')
+    await new Promise((res) => setTimeout(res, 500))
+    router.push('/task/new')
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm p-6 border rounded-lg shadow-md space-y-4">
+        <div>
+          <label className="block mb-1">Email</label>
+          <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+          {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
+        </div>
+        <div>
+          <label className="block mb-1">Password</label>
+          <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        </div>
+        <Button type="submit" className="w-full">Login</Button>
+      </form>
+    </div>
+  )
+}

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+import Button from '../components/Button'
+
+export default function Home() {
+  return (
+    <main className="min-h-screen flex items-center justify-center text-center px-4">
+      <div>
+        <h1 className="text-4xl font-bold mb-2">Ecosleek Dev Assistant</h1>
+        <p className="text-gray-500 mb-6">AI-powered memory-based coding assistant</p>
+        <Link href="/login">
+          <Button>Login</Button>
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/apps/frontend/app/task/[id]/page.tsx
+++ b/apps/frontend/app/task/[id]/page.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useState } from 'react'
+import ChatMessage from '../../../components/ChatMessage'
+import ChatInput from '../../../components/ChatInput'
+
+interface Params {
+  id: string
+}
+
+export default function TaskPage({ params }: { params: Params }) {
+  const [messages, setMessages] = useState<{ role: 'user' | 'assistant'; message: string }[]>([])
+
+  const handleSend = (msg: string) => {
+    setMessages((prev) => [...prev, { role: 'user', message: msg }])
+    console.log('Send message, create chat ID if new:', params.id)
+  }
+
+  return (
+    <div className="min-h-screen pb-24 px-4 flex flex-col">
+      <div className="flex-1 pt-4 flex flex-col">
+        {messages.map((m, i) => (
+          <ChatMessage key={i} role={m.role} message={m.message} />
+        ))}
+      </div>
+      <ChatInput onSend={handleSend} />
+    </div>
+  )
+}

--- a/apps/frontend/components/Button.tsx
+++ b/apps/frontend/components/Button.tsx
@@ -1,0 +1,10 @@
+import { ButtonHTMLAttributes } from 'react'
+
+export default function Button({ className = '', ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={`px-4 py-2 rounded-md bg-primary text-white hover:bg-blue-500 transition ${className}`}
+      {...props}
+    />
+  )
+}

--- a/apps/frontend/components/ChatInput.tsx
+++ b/apps/frontend/components/ChatInput.tsx
@@ -1,0 +1,30 @@
+import { useState, FormEvent } from 'react'
+import Input from './Input'
+import Button from './Button'
+
+export interface ChatInputProps {
+  onSend: (message: string) => void
+}
+
+export default function ChatInput({ onSend }: ChatInputProps) {
+  const [text, setText] = useState('')
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (!text.trim()) return
+    onSend(text)
+    setText('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="fixed bottom-0 left-0 right-0 p-4 bg-white flex gap-2 border-t">
+      <Input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Type your message..."
+        className="flex-1"
+      />
+      <Button type="submit">Send</Button>
+    </form>
+  )
+}

--- a/apps/frontend/components/ChatMessage.tsx
+++ b/apps/frontend/components/ChatMessage.tsx
@@ -1,0 +1,13 @@
+interface ChatMessageProps {
+  role: 'user' | 'assistant'
+  message: string
+}
+
+export default function ChatMessage({ role, message }: ChatMessageProps) {
+  const isUser = role === 'user'
+  const bubbleClass = isUser ? 'bg-graybubble self-end' : 'bg-primary text-white self-start'
+
+  return (
+    <div className={`px-3 py-2 rounded-md max-w-xs mb-2 ${bubbleClass}`}>{message}</div>
+  )
+}

--- a/apps/frontend/components/Input.tsx
+++ b/apps/frontend/components/Input.tsx
@@ -1,0 +1,10 @@
+import { InputHTMLAttributes } from 'react'
+
+export default function Input(props: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+      {...props}
+    />
+  )
+}

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/apps/frontend/postcss.config.js
+++ b/apps/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#60a5fa',
+        graybubble: '#e5e7eb',
+      },
+      fontFamily: {
+        sans: ['var(--font-roboto)', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+}
+export default config

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "allowJs": true,
+    "incremental": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "workspaces": ["apps/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- initialize monorepo workspaces
- add Next.js 14 frontend with Tailwind and Roboto font
- implement Home, Login and Task Chat pages
- add reusable UI components

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68776b7d43d88326b1e1dc9ee019ebe9